### PR TITLE
Adiciona canal de feedback com envio via SendGrid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# SMTP configuration for the feedback mailer
+SMTP_HOST=smtp.seuprovedor.com
+SMTP_PORT=587
+SMTP_USER=seu_usuario
+SMTP_PASS=sua_senha
+
+# Set to "true" when using SMTPS (port 465). For STARTTLS keep "false".
+SMTP_SECURE=false
+
+# Optional overrides for sender/recipient
+# FEEDBACK_FROM=Binario em Palavras <no-reply@seu-dominio.com>
+# FEEDBACK_TO=souzacarvalhosamuel@gmail.com

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .vite/
+.vercel

--- a/api/send-feedback.js
+++ b/api/send-feedback.js
@@ -1,0 +1,149 @@
+const nodemailer = require("nodemailer");
+
+/**
+ * Vercel serverless function responsável por enviar e-mails com o feedback dos usuários.
+ * Espera um corpo em JSON com os campos:
+ * - type: "bug" | "suggestion" (string obrigatória)
+ * - name, email, message, page, userAgent
+ */
+module.exports = async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).json({ error: "Método não suportado." });
+  }
+
+  const {
+    type,
+    name = "",
+    email = "",
+    message = "",
+    page = "",
+    userAgent = "",
+  } = req.body || {};
+
+  if (!type || !message || typeof message !== "string") {
+    return res.status(400).json({ error: "Dados de feedback inválidos." });
+  }
+
+  const trimmedMessage = message.trim();
+
+  if (!trimmedMessage) {
+    return res.status(400).json({ error: "A descrição não pode estar vazia." });
+  }
+
+  try {
+    const transporter = createTransporter();
+    const emailPayload = buildEmailPayload({
+      type,
+      name,
+      email,
+      message: trimmedMessage,
+      page,
+      userAgent,
+    });
+
+    await transporter.sendMail(emailPayload);
+
+    return res.status(200).json({ ok: true });
+  } catch (error) {
+    console.error("Erro ao enviar feedback:", error);
+    return res.status(500).json({ error: "Não foi possível enviar o feedback." });
+  }
+};
+
+function createTransporter() {
+  const host = process.env.SMTP_HOST;
+  const port = Number(process.env.SMTP_PORT || 587);
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+
+  if (!host || !user || !pass) {
+    throw new Error("Variáveis de ambiente SMTP não configuradas.");
+  }
+
+  const secure =
+    typeof process.env.SMTP_SECURE === "string"
+      ? process.env.SMTP_SECURE === "true"
+      : port === 465;
+
+  return nodemailer.createTransport({
+    host,
+    port,
+    secure,
+    auth: {
+      user,
+      pass,
+    },
+  });
+}
+
+function buildEmailPayload({
+  type,
+  name,
+  email,
+  message,
+  page,
+  userAgent,
+}) {
+  const subjectPrefix =
+    type === "bug" ? "[Binário em Palavras] Bug reportado" : "[Binário em Palavras] Sugestão recebida";
+  const subject = subjectPrefix;
+
+  const safeName = sanitize(name);
+  const safeEmail = sanitize(email);
+  const safeMessage = sanitize(message);
+  const safePage = sanitize(page);
+  const safeUserAgent = sanitize(userAgent);
+
+  const html = `
+    <h2>${subjectPrefix}</h2>
+    <p><strong>Tipo:</strong> ${sanitize(type)}</p>
+    ${safeName ? `<p><strong>Nome:</strong> ${safeName}</p>` : ""}
+    ${safeEmail ? `<p><strong>E-mail:</strong> ${safeEmail}</p>` : ""}
+    <p><strong>Mensagem:</strong></p>
+    <p>${safeMessage.replace(/\n/g, "<br />")}</p>
+    ${safePage ? `<p><strong>Página:</strong> <a href="${safePage}">${safePage}</a></p>` : ""}
+    ${safeUserAgent ? `<p><strong>Navegador:</strong> ${safeUserAgent}</p>` : ""}
+  `;
+
+  const text = [
+    subjectPrefix,
+    `Tipo: ${type}`,
+    safeName ? `Nome: ${safeName}` : "",
+    safeEmail ? `E-mail: ${safeEmail}` : "",
+    "Mensagem:",
+    message,
+    safePage ? `Página: ${page}` : "",
+    safeUserAgent ? `Navegador: ${userAgent}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return {
+    from: process.env.FEEDBACK_FROM || process.env.SMTP_USER,
+    to: process.env.FEEDBACK_TO || "souzacarvalhosamuel@gmail.com",
+    replyTo: safeEmail || undefined,
+    subject,
+    text,
+    html,
+  };
+}
+
+function sanitize(value) {
+  if (!value) {
+    return "";
+  }
+  return String(value)
+    .slice(0, 1200)
+    .replace(/[&<>"'`]/g, (char) => {
+      const map = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+        "`": "&#96;",
+      };
+      return map[char] || char;
+    });
+}

--- a/index.html
+++ b/index.html
@@ -396,6 +396,140 @@
         </section>
       </main>
 
+      <section class="app-section" aria-labelledby="feedback-title">
+        <div class="feedback-trigger d-grid">
+          <button
+            class="btn btn-custom-primary btn-lg d-inline-flex align-items-center justify-content-center gap-2 collapsed"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#feedbackCollapse"
+            aria-expanded="false"
+            aria-controls="feedbackCollapse"
+          >
+            <i class="bi bi-chat-dots" aria-hidden="true"></i>
+            Compartilhe seu feedback
+            <i class="bi bi-chevron-down small" aria-hidden="true" data-feedback-chevron></i>
+          </button>
+        </div>
+
+        <article id="feedbackCollapse" class="collapse app-feedback-collapse" aria-labelledby="feedback-title">
+          <div class="app-card app-card--feedback bg-custom-page shadow p-4 p-lg-5">
+            <header class="app-card__header mb-4">
+              <h2 class="h3 fw-bold mb-2 d-flex align-items-center gap-2" id="feedback-title">
+                <i class="bi bi-chat-dots" aria-hidden="true"></i>
+                Envie uma mensagem
+              </h2>
+              <p class="mb-0 text-secondary">
+                Encontrou um problema ou tem uma ideia? Escolha o tipo de feedback e descreva o que aconteceu.
+              </p>
+            </header>
+
+            <div class="feedback-type-group" role="radiogroup" aria-label="Selecionar tipo de feedback">
+              <div class="form-check form-check-inline">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="feedbackType"
+                  id="feedbackTypeBug"
+                  value="bug"
+                  data-feedback-radio
+                />
+                <label class="form-check-label" for="feedbackTypeBug">
+                  <i class="bi bi-bug" aria-hidden="true"></i>
+                  <span>Reportar bug</span>
+                </label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  name="feedbackType"
+                  id="feedbackTypeSuggestion"
+                  value="suggestion"
+                  data-feedback-radio
+                  checked
+                />
+                <label class="form-check-label" for="feedbackTypeSuggestion">
+                  <i class="bi bi-lightbulb" aria-hidden="true"></i>
+                  <span>Sugerir melhoria</span>
+                </label>
+              </div>
+            </div>
+
+            <form id="feedbackForm" class="feedback-form" novalidate>
+              <div class="row gy-3">
+                <div class="col-md-6">
+                  <label class="form-label fw-semibold" for="feedbackName">Nome (opcional)</label>
+                  <input
+                    id="feedbackName"
+                    type="text"
+                    class="form-control input-custom"
+                    maxlength="80"
+                    autocomplete="name"
+                    data-feedback-field="name"
+                  />
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label fw-semibold" for="feedbackEmail">
+                    E-mail <span class="text-danger">*</span>
+                  </label>
+                  <input
+                    id="feedbackEmail"
+                    type="email"
+                    class="form-control input-custom"
+                    placeholder="nome@email.com"
+                    autocomplete="email"
+                    required
+                    data-feedback-field="email"
+                    aria-describedby="feedbackEmailHelp"
+                  />
+                  <small id="feedbackEmailHelp" class="form-text text-muted">
+                    Usaremos esse endereço apenas para responder ao seu contato.
+                  </small>
+                </div>
+                <div class="col-12">
+                  <label class="form-label fw-semibold" for="feedbackMessage">
+                    Descrição <span class="text-danger">*</span>
+                  </label>
+                  <textarea
+                    id="feedbackMessage"
+                    class="form-control input-custom"
+                    rows="5"
+                    required
+                    maxlength="1000"
+                    data-feedback-field="message"
+                    aria-describedby="feedbackMessageHelp"
+                    placeholder="Descreva com detalhes o que aconteceu ou a sua sugestão."
+                  ></textarea>
+                  <div class="d-flex justify-content-between align-items-center mt-2">
+                    <small id="feedbackMessageHelp" class="form-text text-muted">
+                      Inclua, se possível, passos para reproduzir ou o que você esperava ver.
+                    </small>
+                    <small class="feedback-counter text-muted" data-feedback-counter>0/1000</small>
+                  </div>
+                  <div class="invalid-feedback d-block" data-feedback-error></div>
+                </div>
+              </div>
+              <div class="feedback-actions d-flex flex-column flex-md-row gap-3 mt-4">
+                <button type="submit" class="btn btn-custom-primary btn-lg" data-feedback-submit>
+                  <span data-feedback-submit-text>Enviar feedback</span>
+                  <i class="bi bi-send" aria-hidden="true"></i>
+                </button>
+                <a
+                  href="mailto:souzacarvalhosamuel@gmail.com"
+                  class="btn btn-outline-secondary btn-lg"
+                  data-feedback-mailto
+                >
+                  <i class="bi bi-envelope" aria-hidden="true"></i>
+                  Enviar por e-mail
+                </a>
+              </div>
+              <div class="feedback-status mt-3" role="status" aria-live="polite" data-feedback-status></div>
+            </form>
+          </div>
+        </article>
+      </section>
+
       <footer class="app-footer bg-custom-dark text-center py-3">
         <p class="mb-0 text-custom">
           Desenvolvido por <strong>Samuel de Souza</strong> |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@vercel/speed-insights": "^1.2.0",
         "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.3",
+        "nodemailer": "^6.9.13",
         "sweetalert2": "^11.16.0"
       },
       "devDependencies": {
@@ -923,6 +924,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
+    "nodemailer": "^6.9.13",
     "sweetalert2": "^11.16.0"
   }
 }

--- a/src/css/accessibility.css
+++ b/src/css/accessibility.css
@@ -428,6 +428,42 @@ body.acc-mode--light-background #clearButton:focus {
   color: var(--clear-button-text);
 }
 
+body.acc-mode--high-contrast .btn-outline-secondary {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+body.acc-mode--high-contrast .btn-outline-secondary:hover,
+body.acc-mode--high-contrast .btn-outline-secondary:focus-visible {
+  background-color: rgba(255, 212, 0, 0.2);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+body.acc-mode--negative-contrast .btn-outline-secondary {
+  border-color: rgba(255, 255, 255, 0.65);
+  color: inherit;
+}
+
+body.acc-mode--negative-contrast .btn-outline-secondary:hover,
+body.acc-mode--negative-contrast .btn-outline-secondary:focus-visible {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.85);
+  color: inherit;
+}
+
+body.acc-mode--light-background .btn-outline-secondary {
+  border-color: rgba(148, 163, 184, 0.6);
+  color: var(--text-color);
+}
+
+body.acc-mode--light-background .btn-outline-secondary:hover,
+body.acc-mode--light-background .btn-outline-secondary:focus-visible {
+  background-color: rgba(37, 99, 235, 0.12);
+  border-color: rgba(37, 99, 235, 0.7);
+  color: var(--text-color);
+}
+
 /* ---------- Preferências do usuário ---------- */
 @media (prefers-reduced-motion: reduce) {
   .acc-toggle,

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -178,6 +178,109 @@
   gap: 0.75rem;
 }
 
+.app-card--feedback {
+  border-radius: 1rem;
+  border: 1px solid var(--border-color, rgba(207, 216, 227, 0.8));
+}
+
+.feedback-type-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.feedback-type-group .form-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.feedback-type-group .form-check-input {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin: 0;
+  cursor: pointer;
+}
+
+.feedback-type-group .form-check-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.feedback-type-group .form-check-input:checked + .form-check-label {
+  color: var(--primary-color);
+}
+
+.feedback-type-group .form-check-input:focus-visible + .form-check-label {
+  outline: 2px solid rgba(59, 130, 246, 0.35);
+  outline-offset: 2px;
+}
+
+.feedback-trigger .btn {
+  border-radius: 1rem;
+}
+
+.feedback-trigger .btn:not(.collapsed) [data-feedback-chevron] {
+  transform: rotate(180deg);
+}
+
+.feedback-trigger [data-feedback-chevron] {
+  transition: transform 0.2s ease;
+}
+
+.app-feedback-collapse {
+  margin-top: 1.5rem;
+}
+
+.feedback-form .form-label {
+  font-size: 0.95rem;
+}
+
+.feedback-counter {
+  font-size: 0.85rem;
+}
+
+.feedback-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.feedback-status {
+  min-height: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.btn-outline-secondary {
+  border-width: 2px;
+  border-color: rgba(148, 163, 184, 0.6);
+  color: inherit;
+  background-color: transparent;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.btn-outline-secondary:hover,
+.btn-outline-secondary:focus-visible {
+  background-color: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.8);
+  color: inherit;
+}
+
 /* ---------- Listas utilitárias ---------- */
 .dictionary-list {
   max-height: 400px;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,6 +27,7 @@ function initializeApplication() {
   populateBiblicalPhrases(elements);
   setupClearButton(elements);
   setupPulseButton(elements);
+  setupFeedbackForm();
 }
 
 /**
@@ -45,6 +46,213 @@ function getDomElements() {
     mainContent: document.getElementById("mainContent"),
     pulseButton: document.querySelector(".btn-pulsante"),
   };
+}
+
+const FEEDBACK_STORAGE_KEY = "binario:feedbackType";
+const FEEDBACK_MAX_LENGTH = 1000;
+function setupFeedbackForm() {
+  const form = document.getElementById("feedbackForm");
+
+  if (!form) {
+    return;
+  }
+
+  const typeRadios = Array.from(form.querySelectorAll("[data-feedback-radio]"));
+  const submitButton = form.querySelector("[data-feedback-submit]");
+  const submitText = form.querySelector("[data-feedback-submit-text]");
+  const mailtoLink = form.querySelector("[data-feedback-mailto]");
+  const messageField = form.querySelector('[data-feedback-field="message"]');
+  const nameField = form.querySelector('[data-feedback-field="name"]');
+  const emailField = form.querySelector('[data-feedback-field="email"]');
+  const counterEl = form.querySelector("[data-feedback-counter]");
+  const errorEl = form.querySelector("[data-feedback-error]");
+  const statusEl = form.querySelector("[data-feedback-status]");
+
+  let currentType = getStoredFeedbackType() || "suggestion";
+
+  function setStoredFeedbackType(type) {
+    try {
+      localStorage.setItem(FEEDBACK_STORAGE_KEY, type);
+    } catch {
+      // Ignora falhas de armazenamento
+    }
+  }
+
+  function getStoredFeedbackType() {
+    try {
+      return localStorage.getItem(FEEDBACK_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  function updateCounter() {
+    if (!counterEl || !messageField) {
+      return;
+    }
+    const length = (messageField.value || "").length;
+    counterEl.textContent = `${length}/${FEEDBACK_MAX_LENGTH}`;
+  }
+
+  function setActiveType(type) {
+    currentType = type;
+    typeRadios.forEach((radio) => {
+      radio.checked = radio.value === type;
+    });
+    setStoredFeedbackType(type);
+  }
+
+  function setStatusMessage(message, variant = "muted") {
+    if (!statusEl) {
+      return;
+    }
+    statusEl.textContent = message || "";
+    statusEl.className = `feedback-status mt-3 text-${variant}`;
+  }
+
+  function showFieldError(message) {
+    if (!errorEl) {
+      return;
+    }
+    errorEl.textContent = message || "";
+  }
+
+  setActiveType(currentType);
+  updateCounter();
+  showFieldError("");
+  setStatusMessage("");
+
+  typeRadios.forEach((radio) => {
+    radio.addEventListener("change", () => {
+      if (!radio.checked) {
+        return;
+      }
+      const type = radio.value || "suggestion";
+      setActiveType(type);
+      if (messageField) {
+        messageField.focus();
+      }
+    });
+  });
+
+  if (messageField) {
+    messageField.addEventListener("input", () => {
+      updateCounter();
+      if (messageField.value.trim().length > 0) {
+        showFieldError("");
+      }
+    });
+  }
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    setStatusMessage("");
+
+    if (!messageField || !emailField) {
+      return;
+    }
+
+    const trimmedMessage = messageField.value.trim();
+    const trimmedEmail = emailField.value.trim();
+
+    if (!trimmedMessage) {
+      showFieldError("Descreva o bug ou sugestão antes de enviar.");
+      messageField.focus();
+      return;
+    }
+
+    emailField.value = trimmedEmail;
+    emailField.setCustomValidity("");
+
+    if (!trimmedEmail) {
+      emailField.setCustomValidity("Informe um e-mail para que possamos retornar o contato.");
+      emailField.reportValidity();
+      emailField.focus();
+      setStatusMessage("Informe um e-mail válido antes de enviar.", "danger");
+      return;
+    }
+
+    if (!emailField.checkValidity()) {
+      emailField.reportValidity();
+      emailField.focus();
+      setStatusMessage("Verifique o e-mail digitado e tente novamente.", "danger");
+      return;
+    }
+
+    const payload = {
+      type: currentType,
+      name: nameField ? nameField.value.trim() : "",
+      email: trimmedEmail,
+      message: trimmedMessage,
+      page: window.location.href,
+      userAgent: navigator.userAgent,
+    };
+
+    disableSubmit();
+
+    try {
+      const response = await fetch("/api/send-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error("Falha ao enviar feedback");
+      }
+
+      await response.json();
+
+      await showAlert({
+        title: "Obrigado pelo feedback!",
+        text: "Recebemos sua mensagem e iremos analisá-la com carinho.",
+        icon: "success",
+        confirmButtonText: "Fechar",
+      });
+
+      form.reset();
+      updateCounter();
+      showFieldError("");
+      setStatusMessage("Feedback enviado com sucesso. Obrigado!", "success");
+      setActiveType(currentType); // Reaplica estado visual
+      if (messageField) {
+        messageField.focus();
+      }
+    } catch (error) {
+      console.error("Erro ao enviar feedback:", error);
+      showFieldError("Não foi possível enviar agora. Tente novamente ou use o botão de e-mail.");
+      setStatusMessage("Envio falhou. Caso o problema persista, utilize o e-mail.", "danger");
+      if (mailtoLink) {
+        mailtoLink.focus();
+      }
+      await showAlert({
+        title: "Ops! Algo deu errado",
+        text: "Não conseguimos enviar sua mensagem. Você pode tentar novamente ou enviar diretamente por e-mail.",
+        icon: "error",
+        confirmButtonText: "Entendi",
+      });
+    } finally {
+      enableSubmit();
+    }
+  });
+
+  function disableSubmit() {
+    if (!submitButton || !submitText) {
+      return;
+    }
+    submitButton.setAttribute("disabled", "disabled");
+    submitButton.setAttribute("aria-disabled", "true");
+    submitText.textContent = "Enviando...";
+  }
+
+  function enableSubmit() {
+    if (!submitButton || !submitText) {
+      return;
+    }
+    submitButton.removeAttribute("disabled");
+    submitButton.removeAttribute("aria-disabled");
+    submitText.textContent = "Enviar feedback";
+  }
 }
 
 /**


### PR DESCRIPTION
- incluir seção recolhível de feedback com formulário e seleção bug/sugestão
- validar campos obrigatórios, contador de descrição e fallback mailto com mensagens acessíveis
- persistir preferência do tipo de feedback e integrar envio via API `/api/send-feedback`
- criar função serverless com Nodemailer e exemplo `.env` para configuração SMTP
- ajustar estilos globais dos botões outline para suportar os modos de contraste